### PR TITLE
Projection: keep order of the attributes passed to the operator

### DIFF
--- a/lib/grammar/operators/projection.rb
+++ b/lib/grammar/operators/projection.rb
@@ -10,7 +10,11 @@ module Grammar
 
       def apply(r)
         projection_attrs = @params.split(',')
-        new_rel_attrs = r.attributes_hash.select { |name, _type| projection_attrs.include?(name.to_s) }.to_h
+        new_rel_attrs = projection_attrs.map do |projection_attr|
+          type = r.attributes_hash[projection_attr.to_sym]
+          next unless type
+          [projection_attr.to_sym, type]
+        end.compact.to_h
         if (missing_attrs = projection_attrs.reject { |a| new_rel_attrs.keys.include?(a.to_sym) }).any?
           raise ::Errors::OperatorError.new(to_s, "relation's attributes do not include #{missing_attrs.join(', ')}")
         end

--- a/spec/interpretor_spec.rb
+++ b/spec/interpretor_spec.rb
@@ -184,6 +184,19 @@ RSpec.describe ::Interpretor do
           { role: 'user' }
         ])
       end
+
+      it 'should preserve the order of attributes passed to projection operator' do
+        lines = ['Projects[name, id] -> Res']
+        res_data = subject.run(lines, data)
+        expect(res_data[:Res].to_a).to eq([
+          { name: 'Netvisor', id: 1 },
+          { name: 'Severa', id: 2 }
+        ])
+        expect(res_data[:Res].to_a[0].to_a).to eq([
+          [:name, 'Netvisor'],
+          [:id, 1]
+        ])
+      end
     end
 
     context 'limit' do


### PR DESCRIPTION
Workaround for issue #13 