### PR TITLE
Escape all errors in a user-friendly way

### DIFF
--- a/lib/interpretor.rb
+++ b/lib/interpretor.rb
@@ -10,7 +10,7 @@ class Interpretor
       rpn = ::Grammar::Parser.parse(expression)
       resulting_relation = evaluate(rpn, data)
       data[relation_name.strip.to_sym] = resulting_relation if relation_name
-    rescue ::Errors::OperatorError => e
+    rescue => e
       raise ::Errors::InterpretationError.new(e, line, i, data)
     end
     data

--- a/spec/interpretor_spec.rb
+++ b/spec/interpretor_spec.rb
@@ -378,8 +378,8 @@ RSpec.describe ::Interpretor do
   context 'invalid input' do
     it 'should raise an error if there is no such relation' do
       expect { subject.run(['Dogs[id] -> Res'], data) }.to raise_error(
-        Errors::UnknownRelationError,
-        "Unknown relation 'Dogs'. Known relations include: 'Users', 'Admins', 'UserRoles', 'UsersUserRoles', 'Projects'"
+        Errors::InterpretationError,
+        /Unknown relation 'Dogs'. Known relations include: 'Users', 'Admins', 'UserRoles', 'UsersUserRoles', 'Projects'/
       )
     end
   end


### PR DESCRIPTION
Fix for issue #18 